### PR TITLE
Missing XSD prefix in SPARQL query - test passes locally as RDFLib kn…

### DIFF
--- a/prez/services/spaceprez_service.py
+++ b/prez/services/spaceprez_service.py
@@ -256,6 +256,7 @@ async def get_collection_construct_2(
         PREFIX geo: <{GEO}>
         PREFIX rdfs: <{RDFS}>
         PREFIX skos: <{SKOS}>
+        PREFIX xsd: <{XSD}>
         CONSTRUCT {{
             ?coll rdfs:member ?mem .
         }}


### PR DESCRIPTION
…ows the prefix, but fuseki requires it to be specified. Not sure how to replicate fuseki behaviour in tests.